### PR TITLE
Fix CI Linting issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -67,7 +67,8 @@ issues:
   max-same-issues: 10
 
 output:
-  formats: colored-line-number
+  formats:
+    - format: colored-line-number
   sort-results: true
   print-issued-lines: true
   print-linter-name: true

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/stretchr/testify v1.11.1
 	github.com/stripe/stripe-go/v81 v81.4.0
-	github.com/stripe/stripe-go/v86 v86.1.1
 	github.com/swaggo/http-swagger v1.3.4
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.44.0
@@ -45,7 +44,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -124,7 +124,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/stripe/stripe-go/v81 v81.4.0 h1:AuD9XzdAvl193qUCSaLocf8H+nRopOouXhxqJUzCLbw=
 github.com/stripe/stripe-go/v81 v81.4.0/go.mod h1:C/F4jlmnGNacvYtBp/LUHCvVUJEZffFQCobkzwY1WOo=
-github.com/stripe/stripe-go/v86 v86.1.1/go.mod h1:Co7QRXCKGNOPTugAdvjgRo+KcMtd9hxy+pZMN0yThsQ=
 github.com/swaggo/files v1.0.1 h1:J1bVJ4XHZNq0I46UU90611i9/YzdrF7x92oX1ig5IdE=
 github.com/swaggo/files v1.0.1/go.mod h1:0qXmMNH6sXNf+73t65aKeB+ApmgxdnkQzVTAj2uaMUg=
 github.com/swaggo/http-swagger v1.3.4 h1:q7t/XLx0n15H1Q9/tk3Y9L4n210XzJF5WtnDX64a5ww=
@@ -209,8 +208,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/cache/redis_cache.go
+++ b/internal/cache/redis_cache.go
@@ -1,3 +1,4 @@
+// Package cache
 package cache
 
 import (

--- a/internal/repositories/database.go
+++ b/internal/repositories/database.go
@@ -1,3 +1,4 @@
+// Package repository
 package repository
 
 import (

--- a/internal/services/notification.go
+++ b/internal/services/notification.go
@@ -70,7 +70,7 @@ func (s *notificationService) SendEmail(ctx context.Context, req *models.EmailNo
 		notification.ErrorMessage = err.Error()
 
 		if updateErr := s.repo.UpdateNotificationStatus(ctx, notification.ID, models.StatusFailed, notification.ErrorMessage); updateErr != nil {
-			return nil, fmt.Errorf("Failed to update notification status after send failure: %w", updateErr)
+			return nil, fmt.Errorf("failed to update notification status after send failure: %w", updateErr)
 		}
 
 		return nil, errors.ThirdPartyError("Failed to send notification").WithError(err)

--- a/internal/utils/helper.go
+++ b/internal/utils/helper.go
@@ -1,3 +1,4 @@
+// Package utils
 package utils
 
 import (

--- a/pkg/stripe/client.go
+++ b/pkg/stripe/client.go
@@ -14,7 +14,7 @@ import (
 
 type Event = stripe.Event
 
-// defines the methods that any of payment client must implement.
+// Client defines the methods that any of payment client must implement.
 type Client interface {
 	CreatePaymentIntent(amount int64, currency string, description string, customerID string) (*stripe.PaymentIntent, error)
 	CreatePaymentMethod(cardNumber, cardExpMonth, cardExpYear, cardCVC string) (*stripe.PaymentMethod, error)


### PR DESCRIPTION
Fix staticcheck ST1000, ST1021, and ST1005 CI linting issues.

- Add `// Package <name>` comments to `internal/cache/redis_cache.go`, `internal/repositories/database.go`, and `internal/utils/helper.go` to satisfy ST1000.
- Reformat exported `Client` type comment in `pkg/stripe/client.go` to start with "Client ..." to satisfy ST1021.
- Make error string uncapitalized in `internal/services/notification.go` to satisfy ST1005.

---
*PR created automatically by Jules for task [11946746313762375056](https://jules.google.com/task/11946746313762375056) started by @aaravmahajanofficial*