### PR TITLE
🧪 Add tests for WithDBTimeout

### DIFF
--- a/internal/utils/timeout_test.go
+++ b/internal/utils/timeout_test.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithDBTimeout(t *testing.T) {
+	// Call the function under test
+	ctx, cancel := WithDBTimeout(context.Background())
+	defer cancel()
+
+	// Ensure the returned context and cancel function are not nil
+	require.NotNil(t, ctx)
+	require.NotNil(t, cancel)
+
+	// Extract the deadline from the returned context
+	deadline, ok := ctx.Deadline()
+
+	// Assert that a deadline is set
+	require.True(t, ok, "Expected a deadline to be set on the context")
+
+	// Calculate the expected deadline based on when the function was likely called
+	expectedDeadline := time.Now().Add(DefaultDBTimeout)
+
+	// Assert the deadline is within a reasonable tolerance (e.g., 50ms)
+	assert.WithinDuration(t, expectedDeadline, deadline, 50*time.Millisecond, "Deadline should match DefaultDBTimeout from now")
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that `WithDBTimeout` inside `internal/utils/timeout.go` did not have tests verifying that the deadline was correctly set on the returned context.
📊 **Coverage:** The new tests cover the successful creation of the context, validating that both the context and the cancel function are correctly returned without being nil. It checks that a deadline is present on the context, and most importantly verifies that the deadline is approximately matching `DefaultDBTimeout`.
✨ **Result:** Test coverage for `internal/utils/timeout.go` is now complete, providing a regression safety net ensuring database queries continue defaulting to the correct timeout.

---
*PR created automatically by Jules for task [17163365360042632611](https://jules.google.com/task/17163365360042632611) started by @aaravmahajanofficial*