### PR TITLE
🧪 Add unit tests for ParseInt helper

### DIFF
--- a/internal/utils/helper_test.go
+++ b/internal/utils/helper_test.go
@@ -1,0 +1,62 @@
+package utils_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/aaravmahajanofficial/scalable-ecommerce-platform/internal/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseInt(t *testing.T) {
+	tests := []struct {
+		name          string
+		paramValue    string
+		expectedID    int64
+		expectedError bool
+	}{
+		{
+			name:          "Valid ID",
+			paramValue:    "123",
+			expectedID:    123,
+			expectedError: false,
+		},
+		{
+			name:          "Invalid ID - Not a number",
+			paramValue:    "abc",
+			expectedID:    0,
+			expectedError: true,
+		},
+		{
+			name:          "Invalid ID - Empty string",
+			paramValue:    "",
+			expectedID:    0,
+			expectedError: true,
+		},
+		{
+			name:          "Invalid ID - Float value",
+			paramValue:    "12.3",
+			expectedID:    0,
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "/", nil)
+			assert.NoError(t, err)
+
+			req.SetPathValue("id", tt.paramValue)
+
+			id, err := utils.ParseInt(req, "id")
+
+			if tt.expectedError {
+				assert.Error(t, err)
+				assert.ErrorContains(t, err, "Invalid id ID")
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedID, id)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🎯 **What:** Added tests for the `ParseInt` function inside `internal/utils/helper_test.go` to ensure correctness of URL parameter parsing.
📊 **Coverage:** Covered happy path (valid number), and various edge cases such as empty parameters, non-numerical characters, and float values. Tests use Go 1.22's `req.SetPathValue()` API matching the actual behavior.
✨ **Result:** Improved test reliability and ensured regressions are caught when refactoring utils in the future.

---
*PR created automatically by Jules for task [8861046084767279152](https://jules.google.com/task/8861046084767279152) started by @aaravmahajanofficial*