### PR TITLE
🧹 [Code Health] Remove log.Fatal from config package

### DIFF
--- a/cmd/scalable-ecommerce-platform/main.go
+++ b/cmd/scalable-ecommerce-platform/main.go
@@ -99,7 +99,11 @@ func main() {
 	slog.SetDefault(logger)
 
 	// Load config
-	cfg := config.MustLoad()
+	cfg, err := config.Load()
+	if err != nil {
+		slog.Error("❌ Failed to load configuration", "error", err.Error())
+		os.Exit(1)
+	}
 
 	tracerShutdown, err := initTracer(cfg)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,7 +88,7 @@ type Config struct {
 	Cache        CacheConfig  `yaml:"cache"`
 }
 
-func MustLoad() *Config {
+func Load() (*Config, error) {
 	var configPath string
 
 	configPath = os.Getenv("CONFIG_PATH")
@@ -106,31 +106,31 @@ func MustLoad() *Config {
 				configPath = defaultPath
 				log.Printf("Config path not specified, using default: %s", configPath)
 			} else {
-				log.Fatal("Config path is not set and default ./config/local.yaml not found")
+				return nil, errors.New("config path is not set and default ./config/local.yaml not found")
 			}
 		}
 	}
 
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		log.Fatalf("config file does not exist: %s", configPath)
+		return nil, fmt.Errorf("config file does not exist: %s", configPath)
 	} else if err != nil {
-		log.Fatalf("error accessing config file at %s: %v", configPath, err)
+		return nil, fmt.Errorf("error accessing config file at %s: %v", configPath, err)
 	}
 
 	var cfg Config
 
 	err := cleanenv.ReadConfig(configPath, &cfg)
 	if err != nil {
-		log.Fatalf("cannot read config file: %s", err.Error())
+		return nil, fmt.Errorf("cannot read config file: %s", err.Error())
 	}
 
 	// Environment variables can override the defaults
 	err = cleanenv.ReadEnv(&cfg)
 	if err != nil {
-		log.Fatalf("cannot read environment variables: %s", err.Error())
+		return nil, fmt.Errorf("cannot read environment variables: %s", err.Error())
 	}
 
-	return &cfg
+	return &cfg, nil
 }
 
 func LoadConfigFromPath(configPath string) (*Config, error) {


### PR DESCRIPTION
🎯 **What:** Removed `log.Fatal` from `internal/config/config.go` by replacing `MustLoad` with `Load` which returns an error. The error is now handled gracefully in `cmd/scalable-ecommerce-platform/main.go` which uses `slog.Error` to log the failure before exiting cleanly.
💡 **Why:** Using `log.Fatal` in internal packages prevents callers from being able to handle errors gracefully and safely clean up resources. Moving the process exit logic to the main entry point is a better practice.
✅ **Verification:** Ran `go test ./...` and `go build ./cmd/scalable-ecommerce-platform/` to verify functionality is preserved and compilation succeeds.
✨ **Result:** Improved maintainability by enforcing explicit error handling over panics in core logic.

---
*PR created automatically by Jules for task [6224741821628839676](https://jules.google.com/task/6224741821628839676) started by @aaravmahajanofficial*